### PR TITLE
Added 'level_order' for custom ordering in stacked_barplot

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # scCODA - Single-cell differential composition analysis 
 scCODA allows for identification of compositional changes in high-throughput sequencing count data, especially cell compositions from scRNA-seq.
-It also provides a framework for integration of results directly from *scanpy* and other sources.
+It also provides a framework for integration of results directly from [scanpy](https://scanpy.readthedocs.io/en/stable/) and other sources.
 
 ![scCODA](.github/Figures/Fig1_v10.png)
 
 The statistical methodology and benchmarking performance are described in:
  
-Büttner, Ostner *et al.* (2020). **scCODA: A Bayesian model for compositional single-cell data analysis**
+Büttner, Ostner *et al* (2020). **scCODA: A Bayesian model for compositional single-cell data analysis**
 
 
 [Link](https://www.biorxiv.org/content/10.1101/2020.12.14.422688v1) to article on *BioRxiv*.
@@ -18,9 +18,9 @@ For further information, please refer to the
 
 ## Installation
 
-A functioning python environment (>=3.7) is necessary to run this package.
+Running the package requires a working Python environment (>=3.7).
 
-This package uses the tensorflow (==2.3.2) and tensorflow-probability (==0.11.0) packages.
+This package uses the `tensorflow` (`==2.3.2`) and `tensorflow-probability` (`==0.11.0`) packages.
 The GPU versions of these packages have not been tested with scCODA and are thus not recommended.
     
 **To install scCODA via pip, call**:

--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ The GPU versions of these packages have not been tested with scCODA and are thus
 
     `pip install -r requirements.txt`
 
+- Install the package:
+
+    `python setup.py install`
+
 **Import scCODA in a Python session via**:
 
     import sccoda

--- a/sccoda/util/data_visualization.py
+++ b/sccoda/util/data_visualization.py
@@ -131,8 +131,9 @@ def stacked_barplot(
 
     # option to plot one stacked barplot per sample
     if feature_name == "samples":
-        assert set(level_order) == set(data.obs.index), "level order is inconsistent with levels"
-        data = data[level_order]
+        if level_order:
+            assert set(level_order) == set(data.obs.index), "level order is inconsistent with levels"
+            data = data[level_order]
         g = stackbar(
             data.X,
             type_names=data.var.index,

--- a/sccoda/util/data_visualization.py
+++ b/sccoda/util/data_visualization.py
@@ -95,6 +95,7 @@ def stacked_barplot(
         dpi: Optional[int] = 100,
         cmap: Optional[ListedColormap] = cm.tab20,
         plot_legend: Optional[bool] = True,
+        level_order: List[str] = None
 ) -> plt.Subplot:
 
     """
@@ -130,6 +131,8 @@ def stacked_barplot(
 
     # option to plot one stacked barplot per sample
     if feature_name == "samples":
+        assert set(level_order) == set(data.obs.index), "level order is inconsistent with levels"
+        data = data[level_order]
         g = stackbar(
             data.X,
             type_names=data.var.index,
@@ -141,7 +144,11 @@ def stacked_barplot(
             plot_legend=plot_legend,
             )
     else:
-        levels = pd.unique(data.obs[feature_name])
+        if level_order:
+            assert set(level_order) == set(data.obs[feature_name]), "level order is inconsistent with levels"
+            levels = level_order
+        else:
+            levels = pd.unique(data.obs[feature_name])
         n_levels = len(levels)
         feature_totals = np.zeros([n_levels, data.X.shape[1]])
 


### PR DESCRIPTION
Hi,

just added an option to customize the order in which the different levels (x-axis) in stacked_barplot() are plotted.

Ideally, the ordering would be encoded using pd.Categorical for the `data.obs[feature_name]` column and its inherent order, but the plotting code is currently agnostic of that.